### PR TITLE
Refactor validation for clinical data. 

### DIFF
--- a/src/main/java/nl/thehyve/ocdu/validators/ClinicalDataOcChecks.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/ClinicalDataOcChecks.java
@@ -1,6 +1,9 @@
 package nl.thehyve.ocdu.validators;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.DisplayRule;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import nl.thehyve.ocdu.validators.checks.DataFieldWidthCheck;
@@ -9,8 +12,8 @@ import nl.thehyve.ocdu.validators.clinicalDataChecks.*;
 import nl.thehyve.ocdu.validators.clinicalDataChecks.CRFVersionMatchCrossCheck;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by piotrzakrzewski on 04/05/16.
@@ -79,13 +82,110 @@ public class ClinicalDataOcChecks {
 
     private List<ValidationErrorMessage> getCrossCheckErrors(List<ClinicalData> data) {
         List<ValidationErrorMessage> errors = new ArrayList<>();
+        Map<ClinicalData, ItemDefinition> defMap = buildItemDefMap(data, metadata);
+        Map<ClinicalData, Boolean> showMap = new HashMap<>();
+        Map<String, Set<CRFDefinition>> eventMap = buildEventMap(metadata);
         crossChecks.stream().forEach(
                 check -> {
-                    ValidationErrorMessage error = check.getCorrespondingError(data, metadata, subjectWithEventsTypeList);
+                    ValidationErrorMessage error = check.getCorrespondingError(data, metadata,
+                            defMap, subjectWithEventsTypeList, showMap, eventMap);
                     if (error != null) errors.add(error);
                 }
         );
         return errors;
+    }
+
+
+    private Map<ClinicalData, ItemDefinition> buildItemDefMap(List<ClinicalData> data, MetaData metaData) {
+        Map<ClinicalData, ItemDefinition> itemDefMap = new HashMap<>();
+        data.forEach(clinicalData -> {
+            ItemDefinition itemDefinition = getMatching(clinicalData, metaData);
+            if (itemDefinition != null) {
+                itemDefMap.put(clinicalData, itemDefinition);
+            }
+        });
+        return itemDefMap;
+    }
+
+    private CRFDefinition getMatchingCrf(String eventName, String CRFName, String CRfVersion, MetaData metaData) {
+        Map<String, Set<CRFDefinition>> eventMap = buildEventMap(metaData);
+        Set<CRFDefinition> crfInEvents = eventMap.get(eventName);
+        if (crfInEvents == null) {
+            return null;
+        }
+        List<CRFDefinition> matching = crfInEvents.stream()
+                .filter(crfDefinition -> crfDefinition.getName().equals(CRFName) && crfDefinition.getVersion().equals(CRfVersion)).collect(Collectors.toList());
+        assert matching.size() < 2;
+        if (matching.size() == 0) {
+            return null;
+        } else {
+            return matching.get(0);
+        }
+    }
+
+    private ItemDefinition getMatching(ClinicalData dataPoint, MetaData metaData) {
+        CRFDefinition matchingCrf = getMatchingCrf(dataPoint.getEventName(), dataPoint.getCrfName(), dataPoint.getCrfVersion(), metaData);
+        if (matchingCrf == null) {
+            return null;
+        }
+        Set<ItemDefinition> itemDefinitions = matchingCrf.allItems();
+        List<ItemDefinition> matchingItems = itemDefinitions.stream()
+                .filter(itemDefinition -> itemDefinition.getName().equals(dataPoint.getItem()))
+                .collect(Collectors.toList());
+        assert matchingItems.size() < 2;
+        if (matchingItems.size() == 0) return null;
+        else return matchingItems.get(0);
+    }
+
+    private Map<String, Set<CRFDefinition>> buildEventMap(MetaData metaData) {
+        Map<String, Set<CRFDefinition>> eventMap = new HashMap<>();
+        metaData.getEventDefinitions().stream().forEach(eventDefinition ->
+                {
+                    Set<CRFDefinition> crfNames = eventDefinition.getCrfDefinitions()
+                            .stream()
+                            .collect(Collectors.toSet());
+                    eventMap.put(eventDefinition.getName(), crfNames);
+                }
+        );
+        return eventMap;
+    }
+
+    /*
+    * shown/hidden status is context dependant - it is valid only in context of other data-points for given patient.
+    * This is why hidden/shown is not a field of ClinicalData.
+    * */
+    private Map<ClinicalData, Boolean> buildShownMap(Collection<ClinicalData> data,
+                                                     Map<ClinicalData, ItemDefinition> defMap) {
+        Map<ClinicalData, Boolean> shownMap = new HashMap<>();
+        data.forEach(clinicalData1 -> {
+            ItemDefinition definition = defMap.get(clinicalData1);
+            boolean shown = determineShown(clinicalData1, data, definition);
+            shownMap.put(clinicalData1, shown);
+        });
+        return shownMap;
+    }
+
+    private boolean determineShown(ClinicalData clinicalData1, Collection<ClinicalData> data, ItemDefinition definition) {
+        List<DisplayRule> displayRules = definition.getDisplayRules();
+        boolean satisfied = true;
+        for (DisplayRule displayRule: displayRules)
+            satisfied = isDisplayRuleSatisfied(displayRule, data, clinicalData1.getSsid());
+        return satisfied;
+    }
+
+    private boolean isDisplayRuleSatisfied(DisplayRule displayRule, Collection<ClinicalData> data, String subjectId) {
+        String appliesInCrf = displayRule.getAppliesInCrf();
+        String controlItemName = displayRule.getControlItemName();
+        String optionValue = displayRule.getOptionValue();// This value has to equal value of the controlItemName for given subject
+        for (ClinicalData clinicalData1: data)  {
+            boolean controlItem = clinicalData1.getCrfName().equals(appliesInCrf)
+                    && clinicalData1.getItem().equals(controlItemName)
+                    && clinicalData1.getSsid().equals(subjectId);
+            if (controlItem) {
+                return clinicalData1.getValue().equals(optionValue);
+            }
+        }
+        return true;  // controlItemName does not exist is a separate check - therefore we let it pass here
     }
 
 }

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CRFVersionMatchCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CRFVersionMatchCrossCheck.java
@@ -1,6 +1,8 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.CRFVersionMismatchError;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
@@ -9,6 +11,8 @@ import org.openclinica.ws.beans.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Checks if the CRF-version as specified in the input, matches the CRF-version of existing data for each subject
@@ -19,9 +23,9 @@ import java.util.List;
 public class CRFVersionMatchCrossCheck implements ClinicalDataCrossCheck {
 
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> clinicalDataList, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> subjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
 
-        if (clinicalDataList.isEmpty()) {
+        if (data.isEmpty()) {
             return null;
         }
         // Assumption is that there is only 1 event and 1 CRF in a data file and that the clincalDataList only contains a single subjectID
@@ -29,7 +33,7 @@ public class CRFVersionMatchCrossCheck implements ClinicalDataCrossCheck {
         String studyIdentifier = metaData.getStudyOID();
 
         List<String> offendingNames = new ArrayList<>();
-        for (ClinicalData clinicalDataToUpload : clinicalDataList) {
+        for (ClinicalData clinicalDataToUpload : data) {
             String subjectLabel = clinicalDataToUpload.getSsid();
             List<ClinicalData> clinicalDataPresentInStudy = convertToClinicalData(subjectWithEventsTypeList, subjectLabel, studyIdentifier);
             for (ClinicalData clinicalDataInStudy : clinicalDataPresentInStudy) {

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ClinicalDataCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ClinicalDataCrossCheck.java
@@ -18,100 +18,12 @@ import java.util.stream.Collectors;
  */
 public interface ClinicalDataCrossCheck {
 
-    ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList);
-
-    default Map<String, Set<CRFDefinition>> buildEventMap(MetaData metaData) {
-        Map<String, Set<CRFDefinition>> eventMap = new HashMap<>();
-        metaData.getEventDefinitions().stream().forEach(eventDefinition ->
-                {
-                    Set<CRFDefinition> crfNames = eventDefinition.getCrfDefinitions()
-                            .stream()
-                            .collect(Collectors.toSet());
-                    eventMap.put(eventDefinition.getName(), crfNames);
-                }
-        );
-        return eventMap;
-    }
-
-    default Map<ClinicalData, Integer> buildFieldLengthMap(List<ClinicalData> data, MetaData metaData) {
-        Map<ClinicalData, Integer> lengthMap = new HashMap<>();
-        data.forEach(clinicalData -> {
-            ItemDefinition itemDefinition = getMatching(clinicalData, metaData);
-            Integer length = 0;
-            if (itemDefinition != null) length = itemDefinition.getLength(); // zero means no check
-            lengthMap.put(clinicalData, length);
-        });
-        return lengthMap;
-    }
-
-    default Set<String> getAllItemNames(MetaData metaData) {
-        Set<String> allItems = new HashSet<>();
-        metaData.getItemGroupDefinitions().stream().forEach(itemGroupDefinition ->
-                {
-                    List<ItemDefinition> items = itemGroupDefinition.getItems();
-                    items.stream().forEach(itemDefinition -> {
-                        allItems.add(itemDefinition.getName());
-                    });
-                }
-        );
-        return allItems;
-    }
-
-    default Map<ClinicalData, String> buildDataTypeMap(List<ClinicalData> data, MetaData metaData) {
-        Map<ClinicalData, String> dataTypeMap = new HashMap<>();
-        data.forEach(clinicalData -> {
-            ItemDefinition itemDefinition = getMatching(clinicalData, metaData);
-            if (itemDefinition != null) {
-                dataTypeMap.put(clinicalData, itemDefinition.getDataType());
-            }
-        });
-        return dataTypeMap;
-    }
-
-    //TODO: refactor all cross checks to use buildTemDefMap in place of other map building methods.
-    //TODO: delete the other map building methods.
-    default Map<ClinicalData, ItemDefinition> buildItemDefMap(List<ClinicalData> data, MetaData metaData) {
-        Map<ClinicalData, ItemDefinition> itemDefMap = new HashMap<>();
-        data.forEach(clinicalData -> {
-            ItemDefinition itemDefinition = getMatching(clinicalData, metaData);
-            if (itemDefinition != null) {
-                itemDefMap.put(clinicalData, itemDefinition);
-            }
-        });
-        return itemDefMap;
-    }
-
-
-    default CRFDefinition getMatchingCrf(String eventName, String CRFName, String CRfVersion, MetaData metaData) {
-        Map<String, Set<CRFDefinition>> eventMap = buildEventMap(metaData);
-        Set<CRFDefinition> crfInEvents = eventMap.get(eventName);
-        if (crfInEvents == null) {
-            return null;
-        }
-        List<CRFDefinition> matching = crfInEvents.stream()
-                .filter(crfDefinition -> crfDefinition.getName().equals(CRFName) && crfDefinition.getVersion().equals(CRfVersion)).collect(Collectors.toList());
-        assert matching.size() < 2;
-        if (matching.size() == 0) {
-            return null;
-        } else {
-            return matching.get(0);
-        }
-    }
-
-    default ItemDefinition getMatching(ClinicalData dataPoint, MetaData metaData) {
-        CRFDefinition matchingCrf = getMatchingCrf(dataPoint.getEventName(), dataPoint.getCrfName(), dataPoint.getCrfVersion(), metaData);
-        if (matchingCrf == null) {
-            return null;
-        }
-        Set<ItemDefinition> itemDefinitions = matchingCrf.allItems();
-        List<ItemDefinition> matchingItems = itemDefinitions.stream()
-                .filter(itemDefinition -> itemDefinition.getName().equals(dataPoint.getItem()))
-                .collect(Collectors.toList());
-        assert matchingItems.size() < 2;
-        if (matchingItems.size() == 0) return null;
-        else return matchingItems.get(0);
-    }
-
+    ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData,
+                                                 Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType>                                                         studySubjectWithEventsTypeList, Map<ClinicalData,
+                                                        Boolean> shownMap,
+                                                 Map<String, Set<CRFDefinition>> eventMap);
+    // All the maps are present here for performance reasons - precomputing all the maps before running checks is much
+    // more efficient.
 
     default boolean isDate(String input) {
         DateFormat format = new SimpleDateFormat("yyyy-mm-dd", Locale.ENGLISH);

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CodeListCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CodeListCrossCheck.java
@@ -1,6 +1,7 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.CodeListDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
@@ -11,22 +12,24 @@ import org.openclinica.ws.beans.StudySubjectWithEventsType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by piotrzakrzewski on 17/05/16.
  */
 public class CodeListCrossCheck implements ClinicalDataCrossCheck {
+
+
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         EnumerationError error = new EnumerationError();
-        Map<ClinicalData, ItemDefinition> clinicalDataItemDefinitionMap = buildItemDefMap(data, metaData);
         Map<String, CodeListDefinition> codeListMap = new HashMap<>();
         metaData.getCodeListDefinitions().stream().forEach(codeListDefinition -> {
             codeListMap.put(codeListDefinition.getOcid(), codeListDefinition);
         });
         data.stream().forEach(clinicalData -> {
             List<String> values = clinicalData.getValues();
-            ItemDefinition def = clinicalDataItemDefinitionMap.get(clinicalData);
+            ItemDefinition def = itemDefMap.get(clinicalData);
 
             if (def != null) { // Non existent item is a separate error
                 String codeListRef = def.getCodeListRef();

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CrfCouldNotBeVerifiedCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CrfCouldNotBeVerifiedCrossCheck.java
@@ -2,24 +2,31 @@ package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
 import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.CrfCouldNotBeVerified;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * Created by piotrzakrzewski on 10/05/16.
  */
 public class CrfCouldNotBeVerifiedCrossCheck implements ClinicalDataCrossCheck {
+
+
+    private List<ClinicalData> getcrfCouldNotBeVerifiedOffenders(List<ClinicalData> data, Map<String, Set<CRFDefinition>> eventMap) {
+        return data.stream().filter(clinicalData -> {
+            Set<CRFDefinition> valid = eventMap.get(clinicalData.getEventName());
+            if (valid == null) return true;
+            else return false;
+        }).collect(Collectors.toList());
+    }
+
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
-        Map<String, Set<CRFDefinition>> eventMap = buildEventMap(metaData);
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         List<ClinicalData> crfCouldNotBeVerifiedOffenders = getcrfCouldNotBeVerifiedOffenders(data, eventMap);
         if (crfCouldNotBeVerifiedOffenders.size() > 0) {
             CrfCouldNotBeVerified error = new CrfCouldNotBeVerified();
@@ -31,14 +38,6 @@ public class CrfCouldNotBeVerifiedCrossCheck implements ClinicalDataCrossCheck {
             error.addAllOffendingValues(offendingNames);
             return error;
         } else return null;
-    }
-
-    private List<ClinicalData> getcrfCouldNotBeVerifiedOffenders(List<ClinicalData> data, Map<String, Set<CRFDefinition>> eventMap) {
-        return data.stream().filter(clinicalData -> {
-            Set<CRFDefinition> valid = eventMap.get(clinicalData.getEventName());
-            if (valid == null) return true;
-            else return false;
-        }).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CrfExistsCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/CrfExistsCrossCheck.java
@@ -1,5 +1,6 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
 import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
@@ -15,10 +16,8 @@ import java.util.stream.Collectors;
  */
 public class CrfExistsCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
-        Map<String, Set<CRFDefinition>> eventMap = buildEventMap(metaData);
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         List<ClinicalData> crfNotExistsOffenders = getCrfNotExistsOffenders(data, eventMap);
-
         if (crfNotExistsOffenders.size() > 0) {
             CRFDoesNotExist error = new CRFDoesNotExist();
             List<String> offendingNames = new ArrayList<>();
@@ -26,7 +25,7 @@ public class CrfExistsCrossCheck implements ClinicalDataCrossCheck {
                 String crf = clinicalData.getCrfName();
                 String eventName = clinicalData.getEventName();
                 String version = clinicalData.getCrfVersion();
-                String msg = "CRF: " + crf + " version: " + version + " in event: " + eventName+ " for subject: "
+                String msg = "CRF: " + crf + " version: " + version + " in event: " + eventName + " for subject: "
                         + clinicalData.getSsid();
                 if (!offendingNames.contains(msg)) offendingNames.add(msg);
             });

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/DataFieldWidthCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/DataFieldWidthCrossCheck.java
@@ -1,5 +1,7 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
 import nl.thehyve.ocdu.models.errors.SSIDTooLong;
@@ -8,6 +10,8 @@ import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by piotrzakrzewski on 04/05/16.
@@ -16,7 +20,7 @@ public class DataFieldWidthCrossCheck implements ClinicalDataCrossCheck {
     public static final int SSID_MAX_LENGTH = 30; //TODO: make configurable
 
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap){
         List<String> violatingSSIDs = new ArrayList<>();
         data.stream()
                 .filter(ocEntity -> ocEntity.getSsid().length() > SSID_MAX_LENGTH)

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/EventExistsCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/EventExistsCrossCheck.java
@@ -1,6 +1,8 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.EventDoesNotExist;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
@@ -10,6 +12,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -20,7 +24,7 @@ public class EventExistsCrossCheck implements ClinicalDataCrossCheck {
     private static final Logger log = LoggerFactory.getLogger(EventExistsCrossCheck.class);
 
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         List<String> validEventNames = new ArrayList<>();
         metaData
                 .getEventDefinitions().stream()

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/EventRepeatCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/EventRepeatCrossCheck.java
@@ -1,12 +1,15 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.RepeatInNonrepeatingEvent;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,7 +19,7 @@ import java.util.stream.Collectors;
 public class EventRepeatCrossCheck implements ClinicalDataCrossCheck {
 
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         // if  there is a non repeating event which has repeat higher than 1 return error
         RepeatInNonrepeatingEvent error = new RepeatInNonrepeatingEvent();
         Set<String> offenders = data.stream().filter(clinicalData -> clinicalData.getEventRepeat() > 1)

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/HiddenValueEmptyCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/HiddenValueEmptyCheck.java
@@ -1,6 +1,8 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.DisplayRule;
 import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
@@ -8,6 +10,7 @@ import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by piotrzakrzewski on 08/06/16.
@@ -15,13 +18,12 @@ import java.util.Map;
 public class HiddenValueEmptyCheck implements ClinicalDataCrossCheck {
 
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList) {
-        Map<ClinicalData, ItemDefinition> itemMap = buildItemDefMap(data, metaData);
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         data.stream().forEach(clinicalData -> {
             boolean isEmpty = clinicalData.getValue().equals("");
-            ItemDefinition itemDefinition = itemMap.get(clinicalData.getItem());
+            ItemDefinition itemDefinition = itemDefMap.get(clinicalData);
             if (itemDefinition != null) { // non-existent item is a separate check
-                itemDefinition.getDisplayRules();
+                List<DisplayRule> displayRules = itemDefinition.getDisplayRules();
             }
         });
         return null;

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ItemExistenceCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ItemExistenceCrossCheck.java
@@ -1,12 +1,16 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.ItemDoesNotExist;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,7 +19,7 @@ import java.util.stream.Collectors;
  */
 public class ItemExistenceCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         Set<String> allItemNames = getAllItemNames(metaData);
         Set<String> missing = data.stream().filter(clinicalData -> {
             String item = clinicalData.getItem();
@@ -35,5 +39,18 @@ public class ItemExistenceCrossCheck implements ClinicalDataCrossCheck {
         } else {
             return null;
         }
+    }
+
+    private Set<String> getAllItemNames(MetaData metaData) {
+        Set<String> allItems = new HashSet<>();
+        metaData.getItemGroupDefinitions().stream().forEach(itemGroupDefinition ->
+                {
+                    List<ItemDefinition> items = itemGroupDefinition.getItems();
+                    items.stream().forEach(itemDefinition -> {
+                        allItems.add(itemDefinition.getName());
+                    });
+                }
+        );
+        return allItems;
     }
 }

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ItemLengthCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ItemLengthCrossCheck.java
@@ -1,21 +1,25 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.FieldLengthExceeded;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by piotrzakrzewski on 11/05/16.
  */
 public class ItemLengthCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
-        Map<ClinicalData, Integer> lengthMap = buildFieldLengthMap(data, metaData);
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap)  {
+        Map<ClinicalData, Integer> lengthMap = buildFieldLengthMap(data, itemDefMap);
         FieldLengthExceeded error = new FieldLengthExceeded();
         data.stream().forEach(clinicalData -> {
             String value = clinicalData.getValue();
@@ -31,4 +35,16 @@ public class ItemLengthCrossCheck implements ClinicalDataCrossCheck {
             return error;
         } else return null;
     }
+
+    Map<ClinicalData, Integer> buildFieldLengthMap(List<ClinicalData> data, Map<ClinicalData, ItemDefinition> itemDefMap) {
+        Map<ClinicalData, Integer> lengthMap = new HashMap<>();
+        data.forEach(clinicalData -> {
+            ItemDefinition itemDefinition = itemDefMap.get(clinicalData);
+            Integer length = 0;
+            if (itemDefinition != null) length = itemDefinition.getLength(); // zero means no check
+            lengthMap.put(clinicalData, length);
+        });
+        return lengthMap;
+    }
+
 }

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/MultipleEventsCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/MultipleEventsCrossCheck.java
@@ -1,12 +1,15 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.IncorrectNumberOfEvents;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,7 +18,7 @@ import java.util.stream.Collectors;
  */
 public class MultipleEventsCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         Set<String> eventsUsed = data.stream().map(clinicalData -> clinicalData.getEventName()).collect(Collectors.toSet());
         if (eventsUsed.size() != 1) {
             IncorrectNumberOfEvents error = new IncorrectNumberOfEvents();

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/MultipleStudiesCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/MultipleStudiesCrossCheck.java
@@ -1,12 +1,15 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.IncorrectNumberOfStudies;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,7 +19,7 @@ import java.util.stream.Stream;
  */
 public class MultipleStudiesCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         Stream<ClinicalData> stream = data.stream();
         Set<String> studiesUsed = stream.map(clinicalData -> clinicalData.getStudy()).collect(Collectors.toSet());
         if (studiesUsed.size() != 1) {

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/RangeChecks.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/RangeChecks.java
@@ -1,6 +1,7 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.OcDefinitions.RangeCheck;
@@ -15,11 +16,11 @@ import java.util.*;
  */
 public class RangeChecks implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         RangeCheckViolation error = new RangeCheckViolation();
         Set<String> alreadyReported = new HashSet<>();
         data.forEach(clinicalData -> {
-            ItemDefinition itemDefinition = getMatching(clinicalData, metaData);
+            ItemDefinition itemDefinition = itemDefMap.get(clinicalData);
             if (itemDefinition != null) { // Nonexistent item is a separate error
                 List<RangeCheck> rangeCheckList = itemDefinition.getRangeCheckList();
                 rangeCheckList.forEach(rangeCheck -> {

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/SignificanceCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/SignificanceCrossCheck.java
@@ -1,6 +1,7 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.TooManySignificantDigits;
@@ -8,16 +9,18 @@ import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by piotrzakrzewski on 16/05/16.
  */
 public class SignificanceCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap){
         TooManySignificantDigits error = new TooManySignificantDigits();
         data.forEach(clinicalData -> {
-            ItemDefinition definition = getMatching(clinicalData, metaData);
+            ItemDefinition definition = itemDefMap.get(clinicalData);
             if (definition != null) {
                 addOffendingValues(error, clinicalData, definition);
             }

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/SsidUniqueCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/SsidUniqueCrossCheck.java
@@ -1,14 +1,14 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
+import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.SSIDDuplicated;
 import nl.thehyve.ocdu.models.errors.ValidationErrorMessage;
 import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  */
 public class SsidUniqueCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         HashMap<String, List<String>> rowMap = new HashMap<>();
         data.stream().forEach(clinicalData -> {
             String rowString = toRowIdString(clinicalData);
@@ -40,7 +40,7 @@ public class SsidUniqueCrossCheck implements ClinicalDataCrossCheck {
 
     private List<String> getOffenders(HashMap<String, List<String>> rowMap) {
         List<String> offenders = new ArrayList<>();
-        for (String key: rowMap.keySet()) {
+        for (String key : rowMap.keySet()) {
             List<String> items = rowMap.get(key);
             List<String> uniqueItems = items.stream().distinct().collect(Collectors.toList());
             if (items.size() != uniqueItems.size()) {

--- a/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ValuesNumberCrossCheck.java
+++ b/src/main/java/nl/thehyve/ocdu/validators/clinicalDataChecks/ValuesNumberCrossCheck.java
@@ -1,6 +1,7 @@
 package nl.thehyve.ocdu.validators.clinicalDataChecks;
 
 import nl.thehyve.ocdu.models.OCEntities.ClinicalData;
+import nl.thehyve.ocdu.models.OcDefinitions.CRFDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.ItemDefinition;
 import nl.thehyve.ocdu.models.OcDefinitions.MetaData;
 import nl.thehyve.ocdu.models.errors.TooManyValues;
@@ -9,6 +10,7 @@ import org.openclinica.ws.beans.StudySubjectWithEventsType;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -16,10 +18,9 @@ import java.util.stream.Collectors;
  */
 public class ValuesNumberCrossCheck implements ClinicalDataCrossCheck {
     @Override
-    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, List<StudySubjectWithEventsType> subjectWithEventsTypeList) {
-        Map<ClinicalData, ItemDefinition> dataTypeMap = buildItemDefMap(data, metaData);
+    public ValidationErrorMessage getCorrespondingError(List<ClinicalData> data, MetaData metaData, Map<ClinicalData, ItemDefinition> itemDefMap, List<StudySubjectWithEventsType> studySubjectWithEventsTypeList, Map<ClinicalData, Boolean> shownMap, Map<String, Set<CRFDefinition>> eventMap) {
         List<ClinicalData> violators = data.stream()
-                .filter(clinicalData -> isViolator(clinicalData, dataTypeMap)).collect(Collectors.toList());
+                .filter(clinicalData -> isViolator(clinicalData, itemDefMap)).collect(Collectors.toList());
         if (violators.size() > 0) {
             TooManyValues error = new TooManyValues();
             violators.forEach(clinicalData -> {


### PR DESCRIPTION
Refactor validation for clinical data  to precompute hidden/shown status, ItemDefinitions dictionary and event definition dictionaries before checks, instead of for each check separately.
