### PR TITLE
Upload of ODM to OpenClinica works.

### DIFF
--- a/src/main/java/nl/thehyve/ocdu/models/OcDefinitions/MetaData.java
+++ b/src/main/java/nl/thehyve/ocdu/models/OcDefinitions/MetaData.java
@@ -1,8 +1,11 @@
 package nl.thehyve.ocdu.models.OcDefinitions;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by piotrzakrzewski on 01/05/16.
@@ -53,6 +56,29 @@ public class MetaData {
 
     public void removeCodeListDefinition(CodeListDefinition codeListDefinition) {
         codeListDefinitions.remove(codeListDefinition);
+    }
+
+    /**
+     * Returns a clinical data form's OID based on the name and version.
+     * @param crfName the form name
+     * @param crfVersion the form version
+     * @return an empty {@link String} if the crfName or crfVersion are empty or if
+     * the form's OID can not be found. In other cases it returns the form's OID.
+     */
+    public String findFormOID(String crfName, String crfVersion) {
+        if ((StringUtils.isEmpty(crfName)) ||
+                (StringUtils.isEmpty(crfVersion))) {
+            return "";
+        }
+        for (EventDefinition eventDefinition : eventDefinitions) {
+            for (CRFDefinition crfDefinition : eventDefinition.getCrfDefinitions()) {
+                if ((crfName.equals(crfDefinition.getName())) &&
+                    (crfVersion.equals(crfDefinition.getVersion()))) {
+                    return crfDefinition.getOid();
+                }
+            }
+        }
+        return "";
     }
 
 

--- a/src/main/java/nl/thehyve/ocdu/services/OpenClinicaService.java
+++ b/src/main/java/nl/thehyve/ocdu/services/OpenClinicaService.java
@@ -163,7 +163,7 @@ public class OpenClinicaService {
         SOAPConnectionFactory soapConnectionFactory = SOAPConnectionFactory.newInstance();
         SOAPConnection soapConnection = soapConnectionFactory.createConnection();
         SOAPMessage soapMessage = requestFactory.createDataUploadRequest(username, passwordHash, odm);
-
+        System.out.println("-->" + SoapUtils.soapMessageToString(soapMessage));
         SOAPMessage soapResponse = soapConnection.call(soapMessage, url + "/ws/data/v1");  // Add SOAP endopint to OCWS URL.
         String responseError = SOAPResponseHandler.parseOpenClinicaResponse(soapResponse, "//importDataResponse");
         if (responseError != null) {

--- a/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestDecorators/ImportDataRequestDecorator.java
+++ b/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestDecorators/ImportDataRequestDecorator.java
@@ -1,6 +1,8 @@
 package nl.thehyve.ocdu.soap.SOAPRequestDecorators;
 
-import org.w3c.dom.CDATASection;
+import nl.thehyve.ocdu.soap.ResponseHandlers.SoapUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import javax.xml.soap.SOAPBody;
 import javax.xml.soap.SOAPElement;
@@ -22,8 +24,9 @@ public class ImportDataRequestDecorator implements SoapDecorator {
     public void decorateBody(SOAPEnvelope envelope) throws Exception {
         SOAPBody soapBody = envelope.getBody();
         SOAPElement importRequestElement = soapBody.addChildElement("importRequest", "v1");
-        SOAPElement odmElement = importRequestElement.addChildElement("odm");
-        CDATASection odmCData  = soapBody.getOwnerDocument().createCDATASection(odm);
-        odmElement.appendChild(odmCData);
+        Document odmContentDoc = SoapUtils.simpleString2XmlDoc(odm);
+        Node odmRoot = importRequestElement.getOwnerDocument().importNode(odmContentDoc.getFirstChild(), true);
+
+        importRequestElement.appendChild(odmRoot);
     }
 }

--- a/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactory.java
+++ b/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactory.java
@@ -160,6 +160,7 @@ public class SOAPRequestFactory {
     private void decorateEnvelope(SOAPEnvelope envelope, String nameSpace) throws Exception {
         envelope.addNamespaceDeclaration(apiVersion, nameSpace  + apiVersion);
         envelope.addNamespaceDeclaration("beans", "http://openclinica.org/ws/beans");
+        envelope.addNamespaceDeclaration("OpenClinica", "http://www.openclinica.org/ns/odm_ext_v130/v3.1");
     }
 
     private SOAPMessage getSoapMessage(String username, String passwordHash, String nameSpace) throws Exception {

--- a/src/test/java/nl/thehyve/ocdu/models/OcDefinitions/MetaDataTests.java
+++ b/src/test/java/nl/thehyve/ocdu/models/OcDefinitions/MetaDataTests.java
@@ -1,0 +1,46 @@
+package nl.thehyve.ocdu.models.OcDefinitions;
+
+import nl.thehyve.ocdu.soap.ResponseHandlers.GetStudyMetadataResponseHandler;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPMessage;
+import java.io.File;
+import java.io.FileInputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link MetaData} class
+ * Created by Jacob Rousseau on 28-Jun-2016.
+ * Copyright CTMM-TraIT / NKI (c) 2016
+ */
+public class MetaDataTests {
+
+    private static MetaData metaData;
+
+    @Test
+    public void testFindCRFOID() {
+        String formOID = metaData.findFormOID("", "0.10");
+        assertEquals("", formOID);
+
+        formOID = metaData.findFormOID("", "");
+        assertEquals("", formOID);
+
+        formOID = metaData.findFormOID("MUST-FOR_NON_TTP_STUDY", "");
+        assertEquals("", formOID);
+
+        formOID = metaData.findFormOID("MUST-FOR_NON_TTP_STUDY", "0.10");
+        assertEquals("F_MUSTFOR_NON__010", formOID);
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        File testMetaDataFile = new File("docs/responseExamples/getStudyMetadata3.xml");
+        FileInputStream in = new FileInputStream(testMetaDataFile);
+        MessageFactory messageFactory = MessageFactory.newInstance();
+        SOAPMessage mockedResponseGetMetadata = messageFactory.createMessage(null, in);//soapMessage;
+        metaData = GetStudyMetadataResponseHandler.parseGetStudyMetadataResponse(mockedResponseGetMetadata);
+    }
+}


### PR DESCRIPTION
The uploading of an ODM file finally works by adding the CRF-version and change the way the ODM node is attached to the SOAP-envelope. Note: the CDATA section is not required (see also this discussion on the OpenClinica forum: https://forums.openclinica.com/discussion/15422/soap-importrequest-not-working-despite-valid-odm ).
