### PR TITLE
Fix of OCDI2-152: only the first subject was registered in OpenClinica

### DIFF
--- a/docs/exampleFiles/endToEndTest-data-2.txt
+++ b/docs/exampleFiles/endToEndTest-data-2.txt
@@ -1,2 +1,3 @@
 StudySubjectID	Study	Site	EventName	CRFName	CRFVersion	EventRepeat	age	patient_ID	total_length_occluded_segment_in_cm	male0_female1	occluded_artery	site_occlusion_limb_Left1_right2_both3	test_parameterized_link_v2
-EV-00027	Eventful		Non-repeating Event	MUST-FOR_NON_TTP_STUDY	0.11	1	98	Iquenullus	WAW	3	carotis	4	http://www.example.com
+EV-00031	Eventful		Non-repeating Event	MUST-FOR_NON_TTP_STUDY	0.09	1	98	Iquenullus	WAW	3	carotis	4	http://www.example.com
+EV-00032	Eventful		Non-repeating Event	MUST-FOR_NON_TTP_STUDY	0.09	1	98	Iquenullus	WAW	3	carotis	4	http://www.example.com

--- a/docs/exampleFiles/endToEndTest-events-1.txt
+++ b/docs/exampleFiles/endToEndTest-events-1.txt
@@ -1,2 +1,3 @@
 Study Subject ID	Event Name	Study	Location	Start Date	Start Time	End Date	End Time	Repeat Number
-EV-00027	Non-repeating Event	Eventful	Rotjeknor	02-09-2012	11:25	20-10-2012	18:10	1
+EV-00031	Non-repeating Event	Eventful	Rotjeknor	02-09-2012	11:25	20-10-2012	18:10	1
+EV-00032	Non-repeating Event	Eventful	Rotjeknor	02-09-2012	11:25	20-10-2012	18:10	1

--- a/docs/exampleFiles/endToEndTest-subjects-1.txt
+++ b/docs/exampleFiles/endToEndTest-subjects-1.txt
@@ -1,2 +1,3 @@
 Study Subject ID	Study	Site (optional)	Gender	Date of Birth	Date of Enrollment	Secondary ID
-EV-00027	Eventful		m	01-10-1977	05-07-2016	Pietje Puk
+EV-00031	Eventful		m	01-11-1978	06-07-2016	Jantje van Leiden
+EV-00032	Eventful		m	01-12-1979	07-07-2016	Klaas Vaak

--- a/src/main/java/nl/thehyve/ocdu/services/OpenClinicaService.java
+++ b/src/main/java/nl/thehyve/ocdu/services/OpenClinicaService.java
@@ -64,21 +64,22 @@ public class OpenClinicaService {
             throws Exception {
         log.info("Register patients initialized by: " + username + " on: " + url);
         Collection<ValidationErrorMessage> ret = new ArrayList<>();
-        SOAPMessage soapMessage = requestFactory.createCreateSubject(username, passwordHash, subjects);
-        SOAPConnectionFactory soapConnectionFactory = SOAPConnectionFactory.newInstance();
-        SOAPConnection soapConnection = soapConnectionFactory.createConnection();
-        SOAPMessage soapResponse = soapConnection.call(soapMessage, url + "/ws/studySubject/v1");
-        String error = parseRegisterSubjectsResponse(soapResponse);
-        if (error != null) {
-            String detailedErrorMessage = "Registering subjects against instance " + url + " failed, OC error: " + error;
-            log.error(detailedErrorMessage);
-            ret.add(new ValidationErrorMessage(detailedErrorMessage));
-            return ret;
-        } else {
-            log.info("Registering subjects against instance " + url + " successful, number of subjects:" +
-                    subjects.size());
-            return ret;
+        for (Subject subject : subjects) {
+            SOAPMessage soapMessage = requestFactory.createCreateSubject(username, passwordHash, subject);
+            SOAPConnectionFactory soapConnectionFactory = SOAPConnectionFactory.newInstance();
+            SOAPConnection soapConnection = soapConnectionFactory.createConnection();
+            SOAPMessage soapResponse = soapConnection.call(soapMessage, url + "/ws/studySubject/v1");
+            String error = parseRegisterSubjectsResponse(soapResponse);
+            if (error != null) {
+                String detailedErrorMessage = "Registering subject " + subject.getSsid() + " against instance " + url + " failed, OC error: " + error;
+                log.error(detailedErrorMessage);
+                ret.add(new ValidationErrorMessage(detailedErrorMessage));
+            }
         }
+        log.info("Registered subjects against instance " + url + " completed, number of subjects:" +
+                    subjects.size());
+        return ret;
+
     }
 
     public List<Study> listStudies(String username, String passwordHash, String url) throws Exception { //TODO: handle exceptions

--- a/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactories/CreateSubjectRequestFactory.java
+++ b/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactories/CreateSubjectRequestFactory.java
@@ -24,24 +24,21 @@ import static nl.thehyve.ocdu.soap.SOAPRequestFactories.StudySubjectFactory.crea
 public class CreateSubjectRequestFactory {
     private static QName createRequestQname = new QName("http://openclinica.org/ws/studySubject/v1", "createRequest");
 
-    public static Collection<JAXBElement<CreateRequest>> getCreateRequests(Collection<Subject> subjects) {
-        List<JAXBElement<CreateRequest>> createRequests = subjects.stream().map(subject -> {
-            try {
-                Study study = new Study(subject.getStudy(), subject.getStudy(), subject.getStudy());  //TODO: check if it needs to be an identifier or a name
-                SiteDefinition site = new SiteDefinition();
-                String siteText = subject.getSite();
-                if (siteText != null && !siteText.equals("")) {
-                    site.setSiteOID(siteText); //TODO: We need to get an OID here and not name? Probably we need to use metadata here to get correct site
-                } else {
-                    site = null;
-                }
-                return getCreateRequest(subject, study, site);
-            } catch (DatatypeConfigurationException e) {
-                e.printStackTrace();
-                return null;
+    public static JAXBElement<CreateRequest> getCreateRequests(Subject subject) {
+        try {
+            Study study = new Study(subject.getStudy(), subject.getStudy(), subject.getStudy());  //TODO: check if it needs to be an identifier or a name
+            SiteDefinition site = new SiteDefinition();
+            String siteText = subject.getSite();
+            if (siteText != null && !siteText.equals("")) {
+                site.setSiteOID(siteText); //TODO: We need to get an OID here and not name? Probably we need to use metadata here to get correct site
+            } else {
+                site = null;
             }
-        }).collect(Collectors.toList());
-        return createRequests;
+            return getCreateRequest(subject, study, site);
+        } catch (DatatypeConfigurationException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     private static JAXBElement<CreateRequest> getCreateRequest(Subject subject, Study study, SiteDefinition site) throws DatatypeConfigurationException {

--- a/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactory.java
+++ b/src/main/java/nl/thehyve/ocdu/soap/SOAPRequestFactory.java
@@ -3,7 +3,11 @@ package nl.thehyve.ocdu.soap;
 
 import nl.thehyve.ocdu.models.OCEntities.Study;
 import nl.thehyve.ocdu.models.OCEntities.Subject;
-import nl.thehyve.ocdu.soap.SOAPRequestDecorators.*;
+import nl.thehyve.ocdu.soap.SOAPRequestDecorators.GetStudyMetadataRequestDecorator;
+import nl.thehyve.ocdu.soap.SOAPRequestDecorators.ImportDataRequestDecorator;
+import nl.thehyve.ocdu.soap.SOAPRequestDecorators.IsStudySubjectRequestDecorator;
+import nl.thehyve.ocdu.soap.SOAPRequestDecorators.ScheduleEventRequestDecorator;
+import nl.thehyve.ocdu.soap.SOAPRequestDecorators.listAllStudiesRequestDecorator;
 import nl.thehyve.ocdu.soap.SOAPRequestFactories.CreateSubjectRequestFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.openclinica.ws.beans.EventType;
@@ -17,9 +21,14 @@ import org.w3c.dom.Document;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
-import javax.xml.soap.*;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPEnvelope;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.soap.SOAPHeaderElement;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.soap.SOAPPart;
 import javax.xml.transform.dom.DOMResult;
-import java.util.Collection;
 
 
 /**
@@ -109,15 +118,13 @@ public class SOAPRequestFactory {
         return soapMessage;
     }
 
-    public SOAPMessage createCreateSubject(String userName, String passwordHash, Collection<Subject> subjects
+    public SOAPMessage createCreateSubject(String userName, String passwordHash, Subject subject
             ) throws Exception {
         CreateSubjectRequestFactory factory = new CreateSubjectRequestFactory();
-        Collection<JAXBElement<CreateRequest>> createRequests =  factory.getCreateRequests(subjects);
+        JAXBElement<CreateRequest> createRequest =  factory.getCreateRequests(subject);
         SOAPMessage soapMessage = getSoapMessage(userName, passwordHash, STUDY_SUBJECT_NAME_SPACE);
-        for(JAXBElement createRequest: createRequests) {
-            Document xmlDoc = convertToDocument(createRequest, CreateRequest.class);
-            soapMessage.getSOAPBody().addDocument(xmlDoc);
-        }
+        Document xmlDoc = convertToDocument(createRequest, CreateRequest.class);
+        soapMessage.getSOAPBody().addDocument(xmlDoc);
         return soapMessage;
     }
 

--- a/src/test/java/nl/thehyve/ocdu/soap/SOAPRequestFactoriesTests.java
+++ b/src/test/java/nl/thehyve/ocdu/soap/SOAPRequestFactoriesTests.java
@@ -35,13 +35,8 @@ public class SOAPRequestFactoriesTests {
     public void createSubjectRequestTest() throws Exception {
         Subject s1 = new Subject();
         s1.setSsid("s1");
-        Subject s2 = new Subject();
-        s2.setSsid("s2");
-        Collection<Subject> subjects = new ArrayDeque<>();
-        subjects.add(s1);
-        subjects.add(s2);
-        Collection<JAXBElement<CreateRequest>> createRequests = getCreateRequests(subjects);
-        assertThat(createRequests, iterableWithSize(2));
+        JAXBElement<CreateRequest> createRequest = getCreateRequests(s1);
+        assertThat(createRequest.getValue().getStudySubject().getLabel(), equalTo("s1"));
     }
 
     @Test


### PR DESCRIPTION
Cause was the wrong construction of the createSubject SOAP-request. Changed the subject-registration to create each subject with a separate SOAP-call. This allows you to continue with the registration in case a single call causes an error.
